### PR TITLE
fix: Basic auth fixed

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -23,6 +23,8 @@ type ProxyCtx struct {
 	Session   int64
 	certStore CertStorage
 	Proxy     *ProxyHttpServer
+	// Will prevent second authentication on the already authenticated requests
+	Authenticated bool
 }
 
 type RoundTripper interface {

--- a/https.go
+++ b/https.go
@@ -198,7 +198,7 @@ func (proxy *ProxyHttpServer) handleHttps(w http.ResponseWriter, r *http.Request
 			clientTlsReader := bufio.NewReader(rawClientTls)
 			for !isEof(clientTlsReader) {
 				req, err := http.ReadRequest(clientTlsReader)
-				var ctx = &ProxyCtx{Req: req, Session: atomic.AddInt64(&proxy.sess, 1), Proxy: proxy, UserData: ctx.UserData}
+				var ctx = &ProxyCtx{Req: req, Session: atomic.AddInt64(&proxy.sess, 1), Proxy: proxy, UserData: ctx.UserData, Authenticated: ctx.Authenticated}
 				if err != nil && err != io.EOF {
 					return
 				}


### PR DESCRIPTION
1. BasicConnect handler was preventing other handlers from running
2. Basic was trying to authenticate connection that was already authenticated by BasicConnect